### PR TITLE
Align measured iOS component height with layout constraints

### DIFF
--- a/ios/internals/EnrichedTextInputViewShadowNode.mm
+++ b/ios/internals/EnrichedTextInputViewShadowNode.mm
@@ -55,7 +55,10 @@ Size EnrichedTextInputViewShadowNode::measureContent(const LayoutContext& layout
         });
       }
       
-      return {estimatedSize.width, estimatedSize.height};
+      return {
+        estimatedSize.width,
+        MIN(estimatedSize.height, layoutConstraints.maximumSize.height)
+      };
     }
   } else {
     // on the very first call there is no componentView that we can query for the component height


### PR DESCRIPTION
Now measured component height is at most the layout constraints' maximum allowed height for the component. This way we don't get tons of warnings from the shadow node each time measuring in a scrollable component is done.