### PR TITLE
Make iOS attributes not reappear in empty lines

### DIFF
--- a/ios/utils/ParagraphAttributesUtils.h
+++ b/ios/utils/ParagraphAttributesUtils.h
@@ -1,0 +1,6 @@
+#import <UIKit/UIKit.h>
+#pragma once
+
+@interface ParagraphAttributesUtils : NSObject
++ (BOOL)handleBackspaceInRange:(NSRange)range replacementText:(NSString *)text input:(id)input;
+@end

--- a/ios/utils/ParagraphAttributesUtils.mm
+++ b/ios/utils/ParagraphAttributesUtils.mm
@@ -1,0 +1,43 @@
+#import "ParagraphAttributesUtils.h"
+#import "EnrichedTextInputView.h"
+#import "ParagraphsUtils.h"
+#import "TextInsertionUtils.h"
+
+@implementation ParagraphAttributesUtils
+
+// if the user backspaces the last character in a line, the iOS applies typing attributes from the previous line
+// in the case of some paragraph styles it works especially bad when a list point just appears
+// hence the solution - reset typing attributes
++ (BOOL)handleBackspaceInRange:(NSRange)range replacementText:(NSString *)text input:(id)input {
+  EnrichedTextInputView *typedInput = (EnrichedTextInputView *)input;
+  if(typedInput == nullptr) {
+    return NO;
+  }
+  
+  // we make sure it was a backspace (text with 0 length) and it deleted something (range longer than 0)
+  if(text.length > 0 || range.length == 0) {
+    return NO;
+  }
+  
+  // find a non-newline range of the paragraph
+  NSRange paragraphRange = [typedInput->textView.textStorage.string paragraphRangeForRange:range];
+  NSArray *paragraphs = [ParagraphsUtils getNonNewlineRangesIn:typedInput->textView range:paragraphRange];
+  if(paragraphs.count == 0) {
+    return NO;
+  }
+  
+  NSRange nonNewlineRange = [(NSValue *)paragraphs.firstObject rangeValue];
+  
+  // if the backspace removes the whole content of a paragraph - do the thing
+  if(NSEqualRanges(nonNewlineRange, range)) {
+    // do the replacement manually
+    [TextInsertionUtils replaceText:text at:range additionalAttributes:nullptr input:typedInput withSelection:YES];
+    // reset typing attribtues
+    typedInput->textView.typingAttributes = typedInput->defaultTypingAttributes;
+    return YES;
+  }
+
+  return NO;
+}
+
+@end


### PR DESCRIPTION
This PR fixes two pretty obscure iOS issues;
- backspacing a line until it's empty made attributes from previous line be applied in the empty line. It looked especially dumb with lists/blockquotes that just got put there together with their zero width spaces (so custom drawing as well)
- just changing selection to an empty line that follows some non empty line also used the previous line's attributes. This wasn't as bad because custom drawing from lists/quotes wasn't there, but the indents from them still were there.